### PR TITLE
fix(footer)!: Allow capitals in footer

### DIFF
--- a/cmd/footer.go
+++ b/cmd/footer.go
@@ -52,18 +52,11 @@ func lintFooter(f []string) (errs []error) {
 					}
 				}
 
-				if s[0] == strings.ToUpper(s[0]) {
-					errs = append(errs, errInvalidFooterUpperCase)
-				}
-
 				if strings.Contains(s[0], " ") {
 					errs = append(errs, errInvalidFooterSpace)
 				}
 			}
 
-			if s[1] == strings.ToUpper(s[1]) {
-				errs = append(errs, errInvalidFooterUpperCase)
-			}
 		}
 	}
 

--- a/cmd/footer_test.go
+++ b/cmd/footer_test.go
@@ -80,26 +80,6 @@ func TestLintFooter(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid capitals", func(t *testing.T) {
-		trailers := [][]string{
-			{"KEY: VALUE"},
-			{"KEY: value"},
-			{"key: VALUE"},
-		}
-		want := errInvalidFooterUpperCase
-
-		for _, trailer := range trailers {
-			got := lintFooter(trailer)
-			if got == nil {
-				t.Fatal("want error got nil")
-			}
-
-			if !slices.Contains(got, want) {
-				t.Fatalf("Trailer: [ %v ], want error: [ %v ], got: %v", trailer, want, got)
-			}
-		}
-	})
-
 	t.Run("invalid keys with spaces", func(t *testing.T) {
 		trailer := []string{"key pair: value"}
 		want := errInvalidFooterSpace


### PR DESCRIPTION
Spec actually doesn't mention anything about capitals, only mentions that breaking changes is the only one that can have Spaces, therefore capitals are allowed in the footer